### PR TITLE
Obs boost update to 1.60 for OpenSuSE Tumbleweed

### DIFF
--- a/dist/redhat/strusbase.spec.in
+++ b/dist/redhat/strusbase.spec.in
@@ -198,10 +198,10 @@ Requires: libboost_date_time1_54_0 >= 1.54.0
 BuildRequires: boost-devel
 %endif
 %if %{osufactory}
-Requires: libboost_thread1_56_0 >= 1.56.0
-Requires: libboost_atomic1_56_0 >= 1.56.0
-Requires: libboost_system1_56_0 >= 1.56.0
-Requires: libboost_date_time1_56_0 >= 1.56.0
+Requires: libboost_thread1_60_0 >= 1.60.0
+Requires: libboost_atomic1_60_0 >= 1.60.0
+Requires: libboost_system1_60_0 >= 1.60.0
+Requires: libboost_date_time1_60_0 >= 1.60.0
 BuildRequires: boost-devel
 %endif
 %endif

--- a/dist/redhat/strusbase.spec.in
+++ b/dist/redhat/strusbase.spec.in
@@ -198,10 +198,10 @@ Requires: libboost_date_time1_54_0 >= 1.54.0
 BuildRequires: boost-devel
 %endif
 %if %{osufactory}
-Requires: libboost_thread1_58_0 >= 1.58.0
-Requires: libboost_atomic1_58_0 >= 1.58.0
-Requires: libboost_system1_58_0 >= 1.58.0
-Requires: libboost_date_time1_58_0 >= 1.58.0
+Requires: libboost_thread1_56_0 >= 1.56.0
+Requires: libboost_atomic1_56_0 >= 1.56.0
+Requires: libboost_system1_56_0 >= 1.56.0
+Requires: libboost_date_time1_56_0 >= 1.56.0
 BuildRequires: boost-devel
 %endif
 %endif


### PR DESCRIPTION
OpenSuSE Tumbleweed uses boost 1.60 now.
