### PR TITLE
fixed OSX gcc warnings

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories(
 	"${PROJECT_SOURCE_DIR}/include" )
 link_directories(
 	"${Boost_LIBRARY_DIRS}"
-	"${PROJECT_SOURCE_DIR}/utils" )
+	"${PROJECT_SOURCE_DIR}/src/utils" )
 
 
 # -------------------------------------------

--- a/src/error/CMakeLists.txt
+++ b/src/error/CMakeLists.txt
@@ -15,7 +15,7 @@ include_directories(
 
 link_directories(
 	"${Boost_LIBRARY_DIRS}"
-	"${PROJECT_SOURCE_DIR}/utils"
+	"${PROJECT_SOURCE_DIR}/src/utils"
 )
 
 # -------------------------------------------

--- a/src/error/errorBuffer.cpp
+++ b/src/error/errorBuffer.cpp
@@ -116,7 +116,7 @@ bool ErrorBuffer::setMaxNofThreads( unsigned int maxNofThreads)
 	{
 		if (m_logfilehandle)
 		{
-			fprintf( m_logfilehandle, _TXT("out of memory initializing standard error buffer\n"));
+			fprintf( m_logfilehandle, "%s", _TXT("out of memory initializing standard error buffer\n"));
 		}
 		return false;
 	}
@@ -148,7 +148,7 @@ std::size_t ErrorBuffer::threadidx() const
 		{
 			if (m_logfilehandle)
 			{
-				fprintf( m_logfilehandle, _TXT("number of threads in error buffer exhausted\n"));
+				fprintf( m_logfilehandle, "%s", _TXT("number of threads in error buffer exhausted\n"));
 			}
 			throw std::logic_error( _TXT("number of threads in error buffer exhausted"));
 		}

--- a/src/error/libstrus_error.cpp
+++ b/src/error/libstrus_error.cpp
@@ -25,7 +25,7 @@ DLL_PUBLIC ErrorBufferInterface* strus::createErrorBuffer_standard( FILE* logfil
 	}
 	catch (const std::bad_alloc&)
 	{
-		fprintf( logfilehandle?logfilehandle:stderr, _TXT("out of memory creating error buffer\n"));
+		fprintf( logfilehandle?logfilehandle:stderr, "%s", _TXT("out of memory creating error buffer\n"));
 		return 0;
 	}
 	catch (const std::exception& err)


### PR DESCRIPTION
- `fprintf( f, "a b c d" )` is dangerous, it should be `fprintf( f, "%s", "a b c d" )`
- linking warnings
